### PR TITLE
Fix README grammar and missing image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pylsy is a simple Python library for drawing tables in the terminal/console. Just two lines of code! 
 
- ![image](https://github.com/Leviathan1995/Pylsy/raw/master/zic/span.png)
+ ![image](https://raw.githubusercontent.com/Leviathan1995/Pylsy/master/pzi/span.png)
  
 
 <h2>Install</h2>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Leviathan1995/Pylsy.svg?branch=master)](https://travis-ci.org/Leviathan1995/Pylsy)
 
-Pylsy is a simple Python library draw tables in the terminal/console. Just two lines of code! 
+Pylsy is a simple Python library for drawing tables in the terminal/console. Just two lines of code! 
 
  ![image](https://github.com/Leviathan1995/Pylsy/raw/master/zic/span.png)
  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Leviathan1995/Pylsy.svg?branch=master)](https://travis-ci.org/Leviathan1995/Pylsy)
 
-Pylsy is a simple Python library draw tables in the terminal/console.Just two lines of code! 
+Pylsy is a simple Python library draw tables in the terminal/console. Just two lines of code! 
 
  ![image](https://github.com/Leviathan1995/Pylsy/raw/master/zic/span.png)
  


### PR DESCRIPTION
Preview changes: https://github.com/luqmaan/Pylsy/tree/patch-1

---

The title of the repo is also incorrect.

```
Pylsy is a simple Python library draw tables in the Terminal.Just tow lines of code .
```

Should be

```
Pylsy is a simple Python library for drawing tables in the Terminal. Just two lines of code.
```
