### PR TITLE
Fix multiple print bug

### DIFF
--- a/pylsy/pylsy.py
+++ b/pylsy/pylsy.py
@@ -31,6 +31,8 @@ class pylsytable(object):
                 col[attribute] = dict_values
 
     def create_table(self):
+        self.StrTable = ""
+        self.AttributesLength = []
         for col in self.Table:
             values = list(col.values())[0]
             if self.Lines_num < len(values):


### PR DESCRIPTION
Multiple `print(table)` in the same script does not render properly.(There are multiple columns the added everytime `print(table)` is run.)
That's due to `StrTable` and `AttributesLength` values being appended and not overwritten.
Reinitializing them on `create_table` method solves the problem.
