### PR TITLE
Added multiple times column insertion support

### DIFF
--- a/pylsy/pylsy.py
+++ b/pylsy/pylsy.py
@@ -14,7 +14,7 @@ class pylsytable(object):
         self.Lines_num = 0
         for attribute in self.Attributes:
             col = dict()
-            col[attribute] = ""
+            col[attribute] = []
             self.Table.append(col)
 
     def print_divide(self):
@@ -28,7 +28,7 @@ class pylsytable(object):
         for col in self.Table:
             if attribute in col:
                 dict_values = [str(value) for value in values]
-                col[attribute] = dict_values
+                col[attribute] += dict_values
 
     def create_table(self):
         self.StrTable = ""


### PR DESCRIPTION
Right now, multiple additions to the same column using `add_data()` overwrites that column data.
For example - 

```
table.add_data("name",["venus"])
table.add_data("name",["earth"])
print table
# This only shows "earth" and no "venus".
```

This fix ensures that it's added at end(appended) and not overwritten.
