### PR TITLE
Added bugfix for failed testcase - testAddData

### DIFF
--- a/pylsy/pylsy.py
+++ b/pylsy/pylsy.py
@@ -45,6 +45,8 @@ class pylsytable(object):
     def create_table(self):
         self.StrTable = ""
         self.AttributesLength = []
+        self.Lines_num = 0
+
         for col in self.Table:
             values = list(col.values())[0]
             if self.Lines_num < len(values):

--- a/pylsy/tests/pylsy_test.py
+++ b/pylsy/tests/pylsy_test.py
@@ -29,5 +29,41 @@ class PylsyTableTests(unittest.TestCase):
         with open(os.path.join(TEST_DIR, "correct.out"), "r") as correct_file:
             self.assertEqual(self.table.__str__(), correct_file.read())
 
+    def testAddData(self):
+        # Creating a table with data
+        old_names = [
+                "mercury",
+                "venus",
+                "earth"
+        ]
+        self.table.add_data("name", old_names)
+
+        # This is necessary as it calls `create_table()`,
+        # which calculates Lines_num property.
+        # This is equivalent to calling `print table`
+        self.table.__str__()
+
+        # Overwriting existing table with new data
+        new_names = [
+                "mars",
+                "jupiter"
+        ]
+        self.table.add_data("name", new_names)
+
+        expected_output = "\n".join([
+            "+ - - - - - - - + - - - +",
+            "|     name      |  age  | ",
+            "+ - - - - - - - + - - - +",
+            "|     mars      |       |",
+            "+ - - - - - - - + - - - +",
+            "|    jupiter    |       |",
+            "+ - - - - - - - + - - - +",
+            ""
+        ])
+
+        output = self.table.__str__()
+
+        self.assertEqual(output, expected_output)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following scenario gives incorrect output - 

```
old_names = [
    "mercury",
    "venus",
    "earth"
]
table.add_data("name", old_names)
print table

# Overwriting existing table with new data
new_names = [
    "mars",
    "jupiter"
]
table.add_data("name", new_names)
print table
```

This outputs - 

```
+ - - - - - - - + - - - +
|     name      |  age  |
+ - - - - - - - + - - - +
|     mars      |       |
+ - - - - - - - + - - - +
|    jupiter    |       |
+ - - - - - - - + - - - +
|               |       |
+ - - - - - - - + - - - +
```

That extra line is because of the comparision of `self.Lines_num` property in `create_table` method, more spceifically, this line - `if self.Lines_num < len(values)`.

Reinitializing the `self.Lines_num` property solves the problem, which is done in this pull request.
